### PR TITLE
Adding functionality for setting globalconfig

### DIFF
--- a/lib/puppet/provider/gemsource/gem.rb
+++ b/lib/puppet/provider/gemsource/gem.rb
@@ -9,14 +9,22 @@ Puppet::Type.type(:gemsource).provide(:gem) do
     end
   end
 
+  def configlocation
+    if @resource[:globalconfig] = :true
+      "--config-file /etc/gemrc"
+    else
+      ""
+    end
+  end
+
   def execgem(*args)
-      if Open3.popen3("#{gemexe} sources #{args.join(" ")}")[3].value.success? == false 
+      if Open3.popen3("#{gemexe} #{configlocation} sources #{args.join(" ")}")[3].value.success? == false 
         raise Puppet::Error, "Error running gem sources #{args.join(" ")}"
       end
   end
 
   def exists?
-    Open3.popen3("#{gemexe} sources --list") do |stdin, stdout, stderr|
+    Open3.popen3("#{gemexe} #{configlocation} sources --list") do |stdin, stdout, stderr|
       stdout.each do |line|
         return true if line =~ /^#{resource[:url]}$/
       end

--- a/lib/puppet/type/gemsource.rb
+++ b/lib/puppet/type/gemsource.rb
@@ -12,6 +12,12 @@ Puppet::Type.newtype(:gemsource) do
     defaultto :false
     newvalues(:true, :false)
   end
+  
+  newparam(:globalconfig) do
+    desc "If set to true, the resource will be set globally for the system using /etc/gemrc. Defaults to false"
+    defaultto :false
+    newvalues(:true, :false)
+  end
 
 end
 


### PR DESCRIPTION
This PR allows the user to specify that rubygems sources be set in /etc/gemrc rather than in the pwd or ~ directory in which the process gets executed. Documentation to follow.
