### PR TITLE
Making the error message match the actual command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 Simple Puppet type and provider for managing gem sources
 
 ## Usage
-The gemsource module will add a gemsource type to puppet and enable you to add a custom gemsource to your system. You can add a custom gemsource for Puppet Enterprise or open source puppet. 
+The gemsource module will add a gemsource type to puppet and enable you to add a custom gemsource to your system. You can add a custom gemsource for Puppet Enterprise or open source puppet. The gemsource will also remove a gemsource if present.
 
 ## Parameters
-* `ensure`: [true,false] Specify whether the source is present or not.
+* `ensure`: [present,absent] Specify whether the source is present or not.
 * `globalconfig`: [true,false] If true then gem sources will be configured in /etc/gemrc
-* 'pe': [true,false] If you are using Puppet Enterprise and want to manage the sources of the inbuilt Rubygems rather than the distro, use the pe flag
+* `pe`: [true,false] If you are using Puppet Enterprise and want to manage the sources of the inbuilt Rubygems rather than the distro, use the pe flag
 
 ## Examples
 ```
@@ -27,9 +27,9 @@ gemsource { 'http://another.repo/':
 ```
 
 ## Caveats
-The puppet service will run as root with no environment set on Systemd enabled systems. Typically CentOS 7.x and Ubuntu 14.04. 
+The puppet service will run as root with no environment set on Systemd enabled systems. Typically CentOS 7.x and Ubuntu 14.04.
 This has the effect of creating a .gemrc file in the / directory. Please refer to [ENTERPRISE-833](https://tickets.puppetlabs.com/browse/ENTERPRISE-833)
 for more detail.
 
-The puppet provider uses the gem command to add a new source, and is thus bound by its limitations. Specifically `gem source --add' will try and connect to the 
-repository and will fail to add the repository if it can't connect. 
+The puppet provider uses the gem command to add a new source, and is thus bound by its limitations. Specifically `gem source --add' will try and connect to the
+repository and will fail to add the repository if it can't connect.

--- a/lib/puppet/provider/gemsource/gem.rb
+++ b/lib/puppet/provider/gemsource/gem.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:gemsource).provide(:gem) do
 
   def execgem(*args)
       if Open3.popen3("#{gemexe} #{configlocation} sources #{args.join(" ")}")[3].value.success? == false 
-        raise Puppet::Error, "Error running gem sources #{args.join(" ")}"
+        raise Puppet::Error, "Error running #{gemexe} #{configlocation} #{args.join(" ")}"
       end
   end
 


### PR DESCRIPTION
Small change that allows the user to see a more accurate error message when things go wrong.
